### PR TITLE
Reduce minimum sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.0
-    - android-25
+    - build-tools-26.0.2
+    - android-26
     - extra-android-support
     - extra-android-m2repository
+    - extra-google-m2repository
 
 licenses:
     - 'android-sdk-license-.+'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,12 +5,12 @@ apply from: '../gradle-mvn-push.gradle'
 
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 25
+        minSdkVersion 9
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
minSdk does not need to be so high. 
rxAndroid has minSdk set to 9. it makes sense to follow it.